### PR TITLE
Fix weekly mileage math when athlete mentions non-Strava runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ All notable changes to Coach Dean are tracked here. Each entry includes the user
 
 ---
 
+## 2026-03-07 — Fixed weekly mileage math when athlete mentions non-Strava runs in conversation
+
+**Type:** Bug Fix
+**Reported by:** User feedback (jctennant)
+**User feedback:** "It looks like Coach Dean still has some problems with math and computing how many miles I've run so far in a week. He is not including the four miles that I ran with my wife, because 19 plus 12 would be 31, but add four it would be 35."
+**Root cause:** `computeWeekMileage()` only sums Strava-synced activities from the `activities` table. When the athlete mentions a run in conversation that wasn't tracked in Strava, that mileage is not reflected in the "Mileage so far this week" number passed to the LLM. Coach Dean was aware of the 4 extra miles from conversation history but still used the Strava-only total (19.2 mi) as the baseline, computing 19.2 + 12 = 31 instead of 19.2 + 4 + 12 = 35.2.
+**Fix / Change:** Added a clarifying note to the system prompt on the "Mileage so far this week" line, explicitly stating that it is Strava-synced only and instructing Dean to add any conversationally-mentioned miles before computing weekly totals or projections.
+**Files changed:** src/app/api/coach/respond/route.ts
+
+---
+
 ## 2026-03-06 — Strava data in system prompt (race history, YTD/recent stats, Strava intent detection)
 
 **Type:** Feature

--- a/src/app/api/coach/respond/route.ts
+++ b/src/app/api/coach/respond/route.ts
@@ -668,7 +668,7 @@ ${raceHistory.map((r) => {
 CURRENT TRAINING STATE:
 - Week ${state?.current_week || 1} of training, phase: ${state?.current_phase || "base"}
 - Weekly mileage target: ${state?.weekly_mileage_target || "TBD"} mi
-- Mileage so far this week: ${weekMileageSoFar.toFixed(1)} mi
+- Mileage so far this week: ${weekMileageSoFar.toFixed(1)} mi (Strava-synced only — if the athlete has mentioned any additional runs or miles in conversation that aren't in Strava, add those to this number before computing any weekly totals or projections)
 - Current paces: Easy ${easyPaceRange(profile?.current_easy_pace as string ?? null) || "TBD"}, Tempo ${profile?.current_tempo_pace || "TBD"}, Interval ${profile?.current_interval_pace || "TBD"}
 - Last activity: ${state?.last_activity_summary ? JSON.stringify(state.last_activity_summary) : "None yet"}
 - Active adjustments: ${state?.plan_adjustments || "None"}


### PR DESCRIPTION
computeWeekMileage() only sums Strava-synced activities. When an athlete mentions a run in conversation that wasn't tracked in Strava, those miles are absent from the 'Mileage so far this week' number. Coach Dean was then using that partial baseline for total projections (19.2 + 12 = 31) without folding in the conversationally-mentioned miles (correct: 19.2 + 4 + 12 = 35.2).

Added a note to the system prompt telling Dean that the Strava-synced total is partial, and to add any miles mentioned in conversation before computing weekly totals or projections.

https://claude.ai/code/session_01484EkHukcueW4wRvMqth2x