### PR TITLE
fix: auto-fix 2026-04-12 conversation analysis issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Coach Dean are tracked here. Each entry includes the user
 
 ---
 
+## 2026-04-12 — Fix ghost Strava-connected message, duplicate post-run SMS, and mid-week mileage total
+
+**Type:** Bug Fix
+**Reported by:** Automated conversation analysis (2026-04-11 digest)
+**User feedback:** Ghost "Strava connected" message fired 4× mid-conversation; same 10-mile run triggered 3 separate post-run check-ins; plan summary said "14 mi for the week" when user had already logged 36 mi.
+**Root cause:**
+- **Ghost Strava message:** The OAuth callback (`/api/auth/strava/callback`) sends the "Strava connected" SMS unconditionally on every request. Re-auth flows (e.g. clicking the Strava link again, or hitting the write-scope re-auth route) each trigger a fresh callback → duplicate messages.
+- **Duplicate post-run messages:** The webhook's second dedup guard only checked for a post_run conversation within the last 10 minutes. Strava can re-fire the same activity_id event hours apart (observed at 19:04, 19:15, 19:48 for the same run). The 44-minute gap between the first and third event slipped through the 10-minute window.
+- **Mileage total error:** Dean prescribed "Sun 4/13 · Long run 14mi" for a user who had already logged 36 miles this week, then said "That brings you to 14 mi for the week." No prompt rule existed to require stating the full projected total (existing + new) when mid-week miles are already logged.
+**Fix / Change:**
+- `strava/callback/route.ts`: Query `strava_access_token` from the user record before sending the welcome SMS. If already set (Strava was already connected), skip the SMS. First-time connects still send the message normally.
+- `webhooks/strava/route.ts`: Replaced the 10-minute time-based second guard with a permanent per-activity check: query conversations for an existing `post_run` row with this specific `strava_activity_id`. Falls back to the 10-minute guard only as a race-condition safety net for near-simultaneous events.
+- `coach/respond/route.ts`: Added a `WHEN AN ATHLETE REPORTS MID-WEEK MILEAGE` prompt rule with a `<rule>` block requiring Dean to always state the projected total (existing + new sessions) — never just the new session's distance — when a user discloses their current week mileage.
 ## 2026-04-11 — Comprehensive metric units throughout coaching pipeline
 
 **Type:** Bug Fix


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Three fixes from the 2026-04-11 daily conversation analysis digest (18 users, 176 messages).

---

### P0 — Ghost "Strava connected" message firing 4× mid-conversation (user 5e1535c3)

**Root cause:** `/api/auth/strava/callback` sends the "Strava connected" SMS unconditionally on every request. Re-auth flows (write-scope upgrade, user clicking the link multiple times) each trigger a fresh callback → duplicate messages.

**Fix:** Query `strava_access_token` from the user record before sending. If it's already set, skip the SMS — Strava was already connected. First-time connects are unaffected.

**File:** `src/app/api/auth/strava/callback/route.ts`

---

### P1 — Duplicate post-run messages for same activity (user 5e1535c3)

**Root cause:** The second dedup guard in `webhooks/strava` only looked for a `post_run` conversation within the last **10 minutes**. Strava can re-fire the same `activity_id` event hours later (observed at 19:04, 19:15, 19:48 for the same run — a 44-minute spread). The third event slipped through the time window.

**Fix:** Primary guard now queries `conversations` for an existing `post_run` row matching the exact `strava_activity_id` — a permanent, activity-specific idempotency check. The 10-minute time-based guard is retained as a fallback for race conditions where the conversation row hasn't been stored yet.

**File:** `src/app/api/webhooks/strava/route.ts`

---

### P1 — Plan summary states "14 mi for the week" when user already logged 36 mi (user 2e5a7e92 / Maddy)

**Root cause:** No prompt rule required Dean to include already-logged miles when stating a week total after prescribing a remaining session. Dean wrote "That brings you to 14 mi for the week" (just the new session) when the user had already run 36 mi (correct total: 50 mi).

**Fix:** Added a `PROJECTED WEEK TOTAL` `<rule>` block to the `user_message` system prompt: when a user discloses their current week mileage and Dean is prescribing additional sessions, always state the full projected total (existing + new) — never just the new session's miles.

**File:** `src/app/api/coach/respond/route.ts`

---

## Skipped issues

| Issue | Severity | Reason skipped |
|---|---|---|
| HR zone hallucination — praised "in zone" when HR=144 exceeded 140 ceiling | P1 | Requires comparing post-run HR against an HR ceiling extracted from prior conversation turns — no clean, low-risk hook in the current post_run prompt |
| Beginner plan jumped 1.8 mi run/walk → 4.5 mi continuous (Gwyneth) | P1 | Needs plan-generation constraints for "day-one" athletes; architectural change, too broad to safely patch here |
| Inbound SMS double-processing during onboarding | P2 | P2, skipped per triage rules |

## Test plan

- [x] `npm test` — 223 tests, all passing
- [ ] Verify "Strava connected" SMS not re-sent when Jake re-hits the write-scope re-auth flow
- [ ] Confirm duplicate post-run suppression when Strava fires the same activity_id twice

https://claude.ai/code/session_01KJ1ikf6qUsAv2AQyKs6cWR
EOF
)