### PR TITLE
fix: auto-fix 2026-04-13 conversation analysis issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to Coach Dean are tracked here. Each entry includes the user
 
 ---
 
+## 2026-04-13 — Fix duplicate coach responses from Linq webhook race condition
+
+**Type:** Bug Fix
+**Reported by:** Conversation analysis (user 5e1535c3, also dc936de3)
+**User feedback:** N/A (detected by automated analysis — two near-identical responses sent to same athlete message)
+**Root cause:** When Linq delivers the same webhook twice in rapid succession (retry on timeout or network blip), both deliveries pass the pre-`after()` dedup check before either one has had a chance to insert its conversation row. After the 15-second debounce, both handlers see their own row as the "latest message" and both proceed to call coach/respond, generating two independent Claude responses.
+**Fix / Change:** Added a post-debounce guard that queries all conversation rows with the same `external_message_id` for that user. If more than one row exists (duplicate delivery), only the handler whose row has the lexicographically smallest id proceeds; all others return early. This is a deterministic tiebreak that both handlers resolve to the same winner without coordination.
+**Files changed:** `src/app/api/webhooks/linq/route.ts`, `src/__tests__/api/linq-webhook.test.ts`
+
+---
+
+## 2026-04-13 — Past-race users no longer shown "Taper phase" in coaching context
+
+**Type:** Bug Fix
+**Reported by:** Conversation analysis (user b1b308cf — 50K race on 2026-03-28, still being coached as pre-race)
+**User feedback:** N/A (detected by automated analysis)
+**Root cause:** `computePhase` returns "taper" for any race date where `weeksUntil ≤ 2`, including negative values (past races). This caused `tsPhaseDisplay` in `buildSystemPrompt` to output "Training: Week 4 · Taper phase" even when the race had already happened. The post-race context block (lines 3249-3267) was correctly injecting "race is done, here's recovery guidance", but the contradictory "Taper phase" label in the FACTS block undermined it — the model saw conflicting signals and defaulted to treating the race as upcoming.
+**Fix / Change:** `tsPhaseDisplay` is now an IIFE that detects when the raw phase is "taper" AND `profileRaceDaysUntil ≤ 0` (race has passed), and returns "recovery" instead. The post-race context block is unchanged and continues to provide coaching instructions. `suggestedWeeklyMiles` stays null (the existing `buildPeriodization` taper logic returns null), so no spurious progression targets appear.
+**Files changed:** `src/app/api/coach/respond/route.ts`
+
+---
+
 ## 2026-04-12 — Fix timezone fallback + show Strava location in onboarding closing message
 
 **Type:** Bug Fix / Improvement

--- a/src/__tests__/api/linq-webhook.test.ts
+++ b/src/__tests__/api/linq-webhook.test.ts
@@ -644,4 +644,91 @@ describe("POST /api/webhooks/linq — message routing", () => {
     expect(supabase.from).toHaveBeenCalledWith("conversations");
     expect(global.fetch).not.toHaveBeenCalled();
   });
+
+  it("post-debounce: skips duplicate webhook delivery (same external_message_id, race condition)", async () => {
+    // Simulates two Linq webhook deliveries for the same message slipping through
+    // the pre-after dedup check before either one inserts a conversation row.
+    // After the 15-second debounce, the handler whose row id is NOT the
+    // lexicographically smallest should skip to avoid a double response.
+    vi.useFakeTimers();
+    try {
+      mockTables({
+        // conversations calls in order:
+        //   [0] pre-after dedup check → no existing row (both webhooks pass)
+        //   [1] insert storedMsg → returns "conv-zzz" (lexicographically larger id)
+        //   [2] debounce latest-msg check → same id → no newer message, proceed to dedup guard
+        //   [3] external_message_id check → two rows exist (duplicate delivery!) → "conv-aaa" < "conv-zzz"
+        conversations: [
+          { data: null, error: null },                                               // dedup check
+          { data: { id: "conv-zzz" }, error: null },                                 // insert storedMsg
+          { data: { id: "conv-zzz" }, error: null },                                 // debounce check
+          { data: [{ id: "conv-aaa" }, { id: "conv-zzz" }], error: null },           // duplicate guard
+        ],
+        users: {
+          data: {
+            id: "user-001", onboarding_step: null, timezone: "America/New_York",
+            linq_chat_id: "chat-abc", messaging_opted_out: false,
+            reengagement_sent_at: null, strava_athlete_id: null,
+            dashboard_token: null,
+          },
+          error: null,
+        },
+      });
+
+      const req = makeRequest("+12025551234", "great run today");
+      await POST(req);
+      const flushPromise = flush();
+      await vi.advanceTimersByTimeAsync(25_000);
+      await flushPromise;
+
+      // This handler's row ("conv-zzz") is NOT the canonical one ("conv-aaa" sorts first)
+      // → should skip rather than send a duplicate response
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        expect.stringContaining("coach/respond"),
+        expect.anything()
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("post-debounce: proceeds normally when only one row exists for the external_message_id", async () => {
+    // Normal case: no duplicate delivery — only one row with this external_message_id.
+    vi.useFakeTimers();
+    try {
+      mockTables({
+        // conversations: dedup → null, insert → conv-001, debounce → same id,
+        // duplicate guard → single row (no duplicate), 45s guard → null (no recent reply)
+        conversations: [
+          { data: null, error: null },                           // dedup check
+          { data: { id: "conv-001" }, error: null },             // insert storedMsg
+          { data: { id: "conv-001" }, error: null },             // debounce check
+          { data: [{ id: "conv-001" }], error: null },           // duplicate guard → only one row
+        ],
+        users: {
+          data: {
+            id: "user-001", onboarding_step: null, timezone: "America/New_York",
+            linq_chat_id: "chat-abc", messaging_opted_out: false,
+            reengagement_sent_at: null, strava_athlete_id: null,
+            dashboard_token: null,
+          },
+          error: null,
+        },
+      });
+
+      const req = makeRequest("+12025551234", "how am I doing?");
+      await POST(req);
+      const flushPromise = flush();
+      await vi.advanceTimersByTimeAsync(25_000);
+      await flushPromise;
+
+      // Normal path: single row → no duplicate → should route to coach/respond
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("coach/respond"),
+        expect.objectContaining({ method: "POST" })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
 });

--- a/src/app/api/coach/respond/route.ts
+++ b/src/app/api/coach/respond/route.ts
@@ -3397,7 +3397,17 @@ Do NOT reference the completed race as an upcoming event. Do NOT suggest taper, 
     return est.interval ? `${tsFormatPace(est.interval)} (estimated)` : "TBD";
   })();
   const tsEffectiveWeek = periodization?.effectiveWeek ?? (state?.current_week as number | null) ?? 1;
-  const tsPhaseDisplay = (periodization?.phase ?? (state?.current_phase as string | null) ?? "base");
+  const tsPhaseDisplay = (() => {
+    const rawPhase = periodization?.phase ?? (state?.current_phase as string | null) ?? "base";
+    // When the goal race has already passed, replace "taper" with "recovery" so the
+    // FACTS block doesn't signal an upcoming race to the model. The post-race context
+    // block (injected above in dateContext) already provides the correct coaching
+    // instructions; the contradictory "Taper phase" label was overriding them.
+    if (rawPhase === "taper" && profileRaceDaysUntil !== null && profileRaceDaysUntil <= 0) {
+      return "recovery";
+    }
+    return rawPhase;
+  })();
   const tsPhaseLabel = tsPhaseDisplay.charAt(0).toUpperCase() + tsPhaseDisplay.slice(1);
   const tsDeloadBlock = periodization?.isDeloadWeek
     ? `<rule>RECOVERY WEEK — MANDATORY: Week ${tsEffectiveWeek} is a scheduled recovery week (every 4th week). Reduce volume 25–30% from recent average.${periodization.suggestedWeeklyMiles != null ? ` Target: ~${tsMi(periodization.suggestedWeeklyMiles)} this week.` : ""} No new quality sessions — if there's a tempo or interval in the plan, shorten it or replace with an easy run. Same number of runs, shorter distances. Recovery weeks are when adaptation happens — do not skip this.</rule>\n` : "";

--- a/src/app/api/webhooks/linq/route.ts
+++ b/src/app/api/webhooks/linq/route.ts
@@ -479,6 +479,27 @@ async function handleInboundMessage(
       return;
     }
 
+    // Guard against duplicate webhook deliveries (same external_message_id).
+    // If Linq delivered the same message twice and both slipped through the pre-after
+    // dedup check before either inserted a conversation row, two handlers race to respond.
+    // After the debounce wait, only the handler whose row has the lexicographically
+    // smallest id proceeds; the other skips. The smallest id wins deterministically.
+    if (messageId) {
+      const { data: sameExternalRows } = await supabase
+        .from("conversations")
+        .select("id")
+        .eq("user_id", user.id)
+        .eq("external_message_id", messageId)
+        .eq("role", "user");
+      if (sameExternalRows && (sameExternalRows as Array<{ id: string }>).length > 1) {
+        const ids = (sameExternalRows as Array<{ id: string }>).map(r => r.id).sort();
+        if (ids[0] !== storedMsg.id) {
+          console.log("[linq-webhook] duplicate webhook delivery (post-debounce), skipping:", messageId);
+          return;
+        }
+      }
+    }
+
     // Also guard against double-responses when two messages arrived >15s apart (both pass
     // the newer-message check but fire coach/respond in rapid succession). If an assistant
     // reply was already sent within the last 45 seconds, the first message already triggered


### PR DESCRIPTION
## Summary

Two P1 fixes from the 2026-04-12 conversation analysis email.

---

### Fix 1 — Duplicate coach responses (user 5e1535c3)

**Issue:** An athlete received two near-identical responses to a single message ("80min at 170w cycling..."). The analysis flagged this as a P1 duplicate response issue.

**Root cause:** When Linq retries a webhook before the first delivery's `after()` callback has had a chance to insert its conversation row, both deliveries pass the pre-`after()` dedup check (`SELECT WHERE external_message_id = ?` returns nothing for both). Both handlers proceed, both wait 15 seconds, and both see their own row as the "latest message" — so both call coach/respond and generate independent Claude responses.

**Fix:** After the existing "newer message arrived" debounce check, added a guard that queries all `conversations` rows for the user with the same `external_message_id`. If more than one row exists, only the handler whose row has the lexicographically smallest `id` proceeds; the others return early. The tiebreak is deterministic — both handlers resolve to the same winner.

**Files:** `src/app/api/webhooks/linq/route.ts`, `src/__tests__/api/linq-webhook.test.ts` (2 new tests)

---

### Fix 2 — Past-race users shown "Taper phase" in FACTS block (user b1b308cf)

**Issue:** A user whose 50K race ran on 2026-03-28 (16 days before analysis) was still being coached as if the race were upcoming. The analysis noted `training_state.current_phase = "taper"` and Dean ignoring post-race recovery framing.

**Root cause:** `computePhase` returns `"taper"` for any `weeksUntil ≤ 2` — including negative values (past races). This caused the FACTS block to output `Training: Week 4 · Taper phase` even weeks after the race. The post-race context block (lines 3249–3267 in `coach/respond/route.ts`) correctly injects "the race is done, here's recovery guidance", but the contradictory `Taper phase` label in the same prompt was overriding it.

**Fix:** `tsPhaseDisplay` is now an IIFE that checks `rawPhase === "taper" && profileRaceDaysUntil <= 0` and returns `"recovery"` instead. The post-race context block is unchanged. `suggestedWeeklyMiles` is unaffected (it's already `null` for `"taper"` phase from `buildPeriodization`), so no progression targets are shown for post-race users.

**Files:** `src/app/api/coach/respond/route.ts`

---

## Skipped issues

- **7170bad2 "postpartum" word choice** — Model word-choice hallucination; no code fix possible
- **9f7e9cd2 deload mileage > build weeks** — Plan generation code looks correct; this appears to be stale data from a previous plan generation, not a systematic bug
- **7a704281 impossible pace (1:50/mi)** — Single-user data corruption in the DB, not a code bug
- **034a346f "peak" at week 2** — `computePhase` is correct: with 5–6 weeks to race, "peak" is the right phase per the business rules
- **dc936de3 duplicate Strava connects** — Different component (Strava webhook), needs separate investigation

## Test plan

- [x] `npm test` — 230/230 passing (no regressions)
- [x] New test: duplicate webhook delivery skips the non-canonical handler
- [x] New test: normal single-delivery path still routes to coach/respond

https://claude.ai/code/session_01VL1h4Noqape3dgUiZVqpCW