### PR TITLE
fix: auto-fix 2026-04-14 conversation analysis issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to Coach Dean are tracked here. Each entry includes the user
 
 ---
 
+## 2026-04-15 — Prompt fixes: non-run weekly mileage, sprint outlier flag, same-next-day tempo gate
+
+**Type:** Bug Fix
+**Reported by:** Daily conversation analysis (2026-04-14)
+**User feedback:** N/A — identified via automated analysis
+**Root cause:**
+1. **Issue 4 (b1b308cf)** — WeightTraining post_run messages were injecting the week's running mileage total into the prompt even though the cross-training activity doesn't contribute to it. When a run and a non-run activity synced concurrently, both post_run messages reported the same weekly total (the run was already stored when the WeightTraining prompt was built), confusing athletes into thinking the run's distance hadn't been counted.
+2. **Issue 1 (a56bc698)** — A 5:23/mi split on a recovery run was presented neutrally as a "sprint finish" without flagging it as a likely GPS artifact or anomalous burst. Dean's INSIGHT RULES had no guard for outlier lap/split paces.
+3. **Issue 5 (ac0ab080)** — Athlete reported left ankle tightness and outer knee tightness at mile 3 of a return-to-run effort. When asked about doing a tempo run the next day, Dean conditionally green-lit it ("if ankle and knee are quiet Thursday morning, go for it"). This is a coaching error: tempo-loading tissue that flagged within the last 24 hours is unsafe regardless of morning symptoms.
+**Fix / Change:**
+- For non-run `post_run` triggers (WeightTraining, rides, swims, etc.), replaced the injected `WEEK-TO-DATE RUNNING` figure with an explicit instruction: "Do NOT cite the week's running mileage total — leave weekly mileage commentary for post-run messages." Prevents confusing duplicate mileage reports when concurrent activities fire.
+- Added a bullet to INSIGHT RULES: when any lap or split is >~90 sec/mi faster than the run average, flag it explicitly rather than presenting it neutrally (likely GPS artifact or unintended burst on an easy/recovery run).
+- Added `SAME-NEXT-DAY INTENSITY GATE` rule to the PROACTIVE INJURY section: when an athlete reported pain/tightness during a recent run and asks about doing tempo/intervals the following day, respond with easy-only at most and defer quality sessions ≥2 days out.
 ## 2026-04-12 — Fix ghost Strava-connected message, duplicate post-run SMS, and mid-week mileage total
 
 **Type:** Bug Fix


### PR DESCRIPTION
## Summary

Three P1 fixes from the 2026-04-14 conversation analysis email. All prompt-level changes in `src/app/api/coach/respond/route.ts`. 340 tests passing.

---

### Fix 1 — Non-run activities: suppress weekly running mileage (Issue 4, user b1b308cf)

**Problem:** When a WeightTraining activity and a run synced concurrently, the WeightTraining `post_run` prompt injected the week's running total (which already included the concurrently-stored run). Both messages reported the same "9mi this week" — confusing the athlete and making it seem like the run's distance wasn't counted.

**Root cause:** The non-run branch of `weekMileageContext` injected a `WEEK-TO-DATE RUNNING: X mi` figure, but `computeWeekMileage` runs against all activities already in the DB, so a concurrently-stored run can be included in that total before its own `post_run` message fires.

**Fix:** Replaced the numeric mileage injection for non-run activities with an explicit instruction: _"Do NOT cite the week's running mileage total in your response — leave weekly mileage commentary for post-run messages."_ WeightTraining/cross-training acknowledgments now stay focused on the session itself.

---

### Fix 2 — Sprint outlier on recovery run not flagged (Issue 1, user a56bc698)

**Problem:** Dean cited a 5:23/mi final segment on a recovery-week easy run and described it as part of a "solid recovery-week effort" — no mention that a sub-5:30 pace is anomalous and likely a GPS artifact or very brief burst.

**Root cause:** INSIGHT RULES had no guard for statistically outlier lap/split paces relative to the run average.

**Fix:** Added bullet to INSIGHT RULES: _"If any lap or split shows a pace more than ~90 sec/mi faster than the run's average pace, flag it explicitly rather than presenting it neutrally."_ Includes example framing.

---

### Fix 3 — Conditional tempo green-light issued <24h after reported tightness (Issue 5, user ac0ab080)

**Problem:** Athlete ran 4.5mi (return-to-run after knee/ankle soreness), reported tightness at mile 3. When they asked "what's my go/no-go for Thursday's tempo?" (the very next day), Dean conditionally green-lit it: "if ankle and knee are quiet Thursday morning, go for it." This is unsafe — tempo-loading tissue that flagged within the last 12–24 hours regardless of how it feels the next morning.

**Root cause:** No coaching rule prevented offering a same-next-day intensity green-light after reported pain/tightness.

**Fix:** Added `SAME-NEXT-DAY INTENSITY GATE` rule to the PROACTIVE INJURY section: when an athlete reported pain/tightness during a recent run and asks about tempo/intervals the following day, the correct response is easy-only at most, defer quality sessions ≥2 days out.

---

### Skipped issues

- **Issue 2 (87f12055, indoor track GPS)** — Detecting indoor track scenarios reliably from activity data alone is hard (Strava doesn't surface an "indoor" flag on manual laps). Adding a heuristic based on split patterns risks false positives. Skipped.
- **Issues 6, 7, 8, 10** — P2; skipped per triage rules.
- **Issue 3 (82ce42ba)** — Cleared by the analysis email itself (no hallucination found).
- **Issue 9 (a56bc698 prompt injection)** — Positive finding (no response sent); monitoring note only.