### PR TITLE
fix: auto-fix 2026-04-17 conversation analysis issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to Coach Dean are tracked here. Each entry includes the user
 
 ---
 
+## 2026-04-17 — Four coaching quality fixes from 2026-04-16 conversation analysis
+
+**Type:** Bug Fix
+**Reported by:** Automated daily conversation analysis (2026-04-16, 12 users)
+**User feedback:** N/A
+**Root cause (4 issues):**
+1. **P0 — Per-lap hallucination risk (User 0cb902da):** Dean cited specific lap numbers by index ("laps 3/6/7/8 averaged 155-164 bpm") on a Ride activity. Even when lap data is present, referencing specific indices asserts ordering/identity knowledge that may not be reliable.
+2. **P1 — Overtraining warning on WeightTraining (User b1b308cf):** `planDeviationFlag` fired on a WeightTraining activity with 0 mi, producing a mileage-over-plan warning ("17.1mi vs 6mi planned") that was contextually incoherent and tonally jarring after a weight session.
+3. **P1 — "postpartum" used as synonym for "post-run" (User 7170bad2):** Dean wrote "How did your body feel postpartum on this one?" — "postpartum" means after childbirth, not after a run.
+4. **P1 — Unanswered direct speed question (User 95fd0845):** Athlete asked "how do I get leg speed up" and Dean responded only to the tightness context, ignoring the direct question entirely.
+**Fix / Change:**
+1. Added data guard in the `post_run` user message builder: when lap data is present, instruct Dean to use descriptive language ("several of the harder laps") rather than specific lap indices ("laps 3/6/7/8").
+2. `planDeviationFlag` now returns `null` when `trigger === "post_run"` and the current activity type is not a running type (Run/TrailRun/VirtualRun/Treadmill).
+3. Added prompt instruction: never use "postpartum" as a synonym for "post-run" or "after the activity."
+4. Added `ANSWERING DIRECT QUESTIONS` prompt section: when an athlete asks a direct question, Dean must answer it explicitly, even if the message also contains other context to address.
+**Skipped:** Issue 2 (duplicate messages for User 95fd0845) — the system already deduplicates by `external_message_id`. Content-based dedup within a 30s window would require adding a DB query to the async ingestion path and updating ~15 test mocks. Skipped to avoid risky test churn; worth a dedicated pass.
+**Files changed:** `src/app/api/coach/respond/route.ts`
+
+---
+
 ## 2026-04-16 — Onboarding: name in first message, HR zones + mileage spike at Strava connect
 
 **Type:** Feature / Improvement

--- a/src/app/api/coach/respond/route.ts
+++ b/src/app/api/coach/respond/route.ts
@@ -1497,6 +1497,12 @@ The right response is NOT to prescribe a race-day run/walk strategy — that's p
   // comparing apples to apples with the actual mileage already logged.
   const planDeviationFlag = (() => {
     if (trigger !== "post_run" && trigger !== "weekly_recap") return null;
+    // Volume deviation is meaningless for non-running activities (e.g. WeightTraining with 0 mi).
+    // Applying a mileage-over-plan warning immediately after a weight session is contextually wrong.
+    if (trigger === "post_run" && activityData) {
+      const actType = activityData.activity_type as string | null;
+      if (actType && !["Run", "TrailRun", "VirtualRun", "Treadmill"].includes(actType)) return null;
+    }
     const sessions = (state?.weekly_plan_sessions as Array<{ day: string; date: string; label: string }> | null) ?? [];
     if (!sessions.length) return null;
     const tz = userTimezone || "America/New_York";
@@ -4465,6 +4471,10 @@ TONE:
 - Sound like a knowledgeable friend, not a customer service bot.
 - Use specific numbers for paces and distances. Only state specific dates when they appear explicitly in the data provided to you (activity dates, race date, DATE CONTEXT). Never invent or guess a date.
 - One emoji max per response. Often none is better.
+- Never use "postpartum" to mean "post-run" or "after the activity." "Postpartum" specifically means the period after childbirth. Use "post-run," "after the effort," or "afterward" instead. If the athlete's profile indicates they are postpartum, any check-in must be clearly scoped to that recovery context — do not conflate it with run recovery.
+
+ANSWERING DIRECT QUESTIONS:
+When the athlete asks a direct question, answer it explicitly. Do not address only the surrounding context while ignoring the question itself. If a message contains both a statement and a question (e.g. "legs are tight. how do I get leg speed up?"), address both — the statement first, then the question with a concrete answer. A coaching response that ignores a direct "how do I get faster / stronger / more efficient" question is a material miss.
 
 FORMATTING:
 - NEVER use asterisks, markdown bold/italic, bullet points, or dashes as list markers — SMS does not render markdown and they appear as raw characters.
@@ -5218,6 +5228,9 @@ function buildUserMessage(
       if (!hasCadence) dataGuards.push("No cadence data is available for this activity. Do NOT reference cadence (steps per minute, spm, rpm, or stride rate) — not as a specific value, average, or range.");
       // Per-mile and per-lap elevation breakdown is not a Strava-provided field — only total elevation gain is.
       dataGuards.push("Per-mile and per-lap elevation breakdowns (e.g. '500ft gain on lap 2', '721ft at miles 11-12') are NOT available from Strava. Reference total elevation gain only — do NOT attribute specific footage to individual miles or laps.");
+      // When laps are present, guard against false precision from citing specific lap indices.
+      // The athlete knows their own workout structure; using index numbers adds false certainty.
+      if (hasLaps) dataGuards.push("Lap data is available. When referencing effort patterns, use descriptive language (e.g. 'several of your harder laps averaged 155 bpm', 'the higher-effort segments') rather than citing specific lap numbers by index (e.g. 'laps 3/6/7/8'). Lap indices suggest precise ordering knowledge you may not have — describe the effort pattern instead.");
       // splits_standard gives one split per mile, so splitCount ≈ ceil(runDistanceMiles).
       // Guard: if splits look like km data (far more splits than miles), warn Claude.
       // This handles legacy activities stored before the switch to splits_standard.


### PR DESCRIPTION
## Summary

Four fixes from the 2026-04-16 conversation analysis email (12 users, 61 messages). All 406 tests pass.

---

### Fix 1 — P0: Lap index hallucination risk (User 0cb902da)

**Issue:** Dean cited "laps 3/6/7/8 averaged 155-164 bpm" on a Ride activity. Even with lap data present, naming specific lap indices asserts ordering/identity knowledge that may not be reliable.

**Root cause:** No guard preventing specific lap index references in the `post_run` user message.

**Fix:** Added a data guard when `hasLaps` is true: instructs Dean to use descriptive language ("several of the harder laps averaged 155 bpm", "the higher-effort segments") rather than specific index citations ("laps 3/6/7/8").

---

### Fix 2 — P1: Volume warning on WeightTraining session (User b1b308cf)

**Issue:** `planDeviationFlag` fired on a WeightTraining activity with 0 miles, producing "You've been going longer than the plan all week — 17.1mi vs 6mi planned" immediately after a weight session. Contextually incoherent and tonally jarring.

**Root cause:** `planDeviationFlag` only gated on `trigger === "post_run"` — didn't check whether the current activity was a running activity.

**Fix:** `planDeviationFlag` now returns `null` when `trigger === "post_run"` and `activityData.activity_type` is not in `["Run", "TrailRun", "VirtualRun", "Treadmill"]`.

---

### Fix 3 — P1: "postpartum" used as synonym for "post-run" (User 7170bad2)

**Issue:** Dean wrote "How did your body feel postpartum on this one?" — "postpartum" means after childbirth.

**Root cause:** No language guard in the system prompt.

**Fix:** Added prompt instruction explicitly prohibiting "postpartum" as a synonym for "post-run" or "after the activity."

---

### Fix 4 — P1: Unanswered direct speed question (User 95fd0845)

**Issue:** Athlete asked "how do I get leg speed up" and Dean responded only to the leg tightness context, ignoring the direct question entirely — despite the athlete having stated during onboarding that getting faster was their primary goal.

**Root cause:** No explicit prompt instruction requiring Dean to address all direct questions when a message contains both a statement and a question.

**Fix:** Added `ANSWERING DIRECT QUESTIONS` section to the system prompt: when an athlete asks a direct question, Dean must answer it explicitly — including when it follows a contextual statement.

---

### Skipped — P1: Duplicate messages (User 95fd0845)

Content-based dedup within a 30s window (same body, different message IDs) would require adding a DB query to the async ingestion path and updating ~15 test mocks across `linq-webhook.test.ts`. Skipped to avoid risky test churn; worth a dedicated PR.

---

**Files changed:** `src/app/api/coach/respond/route.ts`, `CHANGELOG.md`